### PR TITLE
breakfix for container and init

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,11 +1,12 @@
 {
   "name": "OpenVPN Client",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "slug": "openvpn_client",
   "description": "OpenVPN Client",
   "url": "https://github.com/Ailme/homeassistant-openvpn-client-addon",
   "arch": ["armhf", "armv7", "aarch64", "amd64", "i386"],
   "startup": "application",
+  "init": false,
   "boot": "auto",
   "host_network": true,
   "privileged": ["NET_ADMIN"],


### PR DESCRIPTION
Breaking changes to [2022.6](https://www.home-assistant.io/blog/2022/06/01/release-20226/#breaking-changes) require `init` is turned off

- added `init:false`
- bumped ver